### PR TITLE
Ensure cookie header is reserved 

### DIFF
--- a/src/_express/handler.js
+++ b/src/_express/handler.js
@@ -11,6 +11,11 @@ exports.handler = async (event, context) => {
   event.path = event.requestContext.http.path
   event.method = event.requestContext.http.method
   event.httpMethod = event.requestContext.http.method
+  // APIG 2.0 extracts cookies from headers automatically.
+  // We need to put `cookie` back to `headers.cookie` so it works with current aws-serverless-express
+  if (event.cookies && event.cookies.length > 0) {
+    event.headers.cookie = event.cookies.join('; ')
+  }
 
   // NOTICE: require() is relative to this file, while existsSync() is relative to the cwd, which is the root of lambda
   let app

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -66,6 +66,29 @@ it('should successfully update source code', async () => {
   expect(response.data).toEqual('hello world')
 })
 
+it('should attach cookies correctly', async () => {
+  instanceYaml.inputs.src = path.resolve(__dirname, 'src')
+
+  const instance = await sdk.deploy(instanceYaml, credentials)
+
+  const response1 = await axios.get(`${instance.outputs.url}/cookie`, {
+    headers: {
+      cookie: 'cookie1=yum'
+    }
+  })
+  expect(response1.data).toEqual('cookie1=yum')
+
+  const response2 = await axios.get(`${instance.outputs.url}/cookie`, {
+    headers: {
+      cookie: 'cookie1=yum; cookie2=hot'
+    }
+  })
+  expect(response2.data).toEqual('cookie1=yum; cookie2=hot')
+
+  const response3 = await axios.get(`${instance.outputs.url}/cookie`)
+  expect(response3.data).toEqual('undefined')
+})
+
 it('should enable traffic shifting', async () => {
   // change source code and apply it to a small subset of traffic
   instanceYaml.inputs.traffic = 0.2

--- a/tests/src/app.js
+++ b/tests/src/app.js
@@ -1,6 +1,10 @@
 const express = require('express')
 const app = express()
 
+app.get('/cookie', function(req, res) {
+  res.send(`${req.headers.cookie}`)
+})
+
 app.get('/*', function(req, res) {
   res.send('hello world')
 })


### PR DESCRIPTION
We are using v2 of [integration payload](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html). In this version, cookies are extracted from `headers` automatically. Since we are using `aws-serverless-express` which currently supports v1, we must put the cookies back to `headers` otherwise they are never forwarded to the lambda.

This fixes https://github.com/serverless-components/express/issues/16

TODO:

- [x] Write tests