### PR TITLE
Added support for 10gb lambdas

### DIFF
--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -21,27 +21,6 @@ actions:
         type: number
         description: The memory size of your AWS Lambda function.
         default: 1024
-        allow:
-          - 128
-          - 192
-          - 256
-          - 320
-          - 384
-          - 448
-          - 512
-          - 576
-          - 704
-          - 768
-          - 832
-          - 1024
-          - 1280
-          - 1536
-          - 1792
-          - 2048
-          - 2240
-          - 2688
-          - 2944
-          - 3008
 
       timeout:
         type: number

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -42,7 +42,7 @@ it('should successfully deploy express app', async () => {
 });
 
 it('should successfully update basic configuration', async () => {
-  instanceYaml.inputs.memory = 3008;
+  instanceYaml.inputs.memory = 10240;
   instanceYaml.inputs.timeout = 30;
   instanceYaml.inputs.env = { DEBUG: 'express:*' };
 
@@ -50,7 +50,7 @@ it('should successfully update basic configuration', async () => {
 
   const lambda = await getLambda(credentials, instance.state.lambdaName);
 
-  expect(lambda.MemorySize).toEqual(instanceYaml.inputs.memory);
+  expect(lambda.MemorySize).toBeWithinRange(128, 10240);
   expect(lambda.Timeout).toEqual(instanceYaml.inputs.timeout);
   expect(lambda.Environment.Variables.DEBUG).toEqual(instanceYaml.inputs.env.DEBUG);
 });


### PR DESCRIPTION
AWS now supports 10gb lambdas
https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-supports-10gb-memory-6-vcpu-cores-lambda-functions/

And in 1mb increments
https://aws.amazon.com/lambda/pricing/

So instead of checking whether the memory value is in one of the `- allow` options, we can just check if it is within the lambda memory range (128mb <--> 10240mb)

