### PR TITLE
Add logic to load the app from a configured dist location if present.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,6 +90,15 @@ const getNakedDomain = (domain) => {
   return nakedDomain;
 };
 
+/**
+ * Determines the appropriate location to load app file from.
+ *
+ * @param ${object} inputs - the component inputs config
+ */
+const getAppDirectory = (inputs) => {
+  return inputs.dist ? inputs.dist : inputs.src;
+};
+
 /*
  * Packages express app and injects shims and sdk
  *
@@ -100,8 +109,8 @@ const packageExpress = async (instance, inputs) => {
   console.log('Packaging Express.js application...');
 
   // unzip source zip file
-  console.log(`Unzipping ${inputs.src || 'files'}...`);
-  const sourceDirectory = await instance.unzip(inputs.src);
+  console.log(`Unzipping ${getAppDirectory() || 'files'}...`);
+  const sourceDirectory = await instance.unzip(getAppDirectory());
   console.log(`Files unzipped into ${sourceDirectory}...`);
 
   // add shim to the source directory
@@ -1366,6 +1375,7 @@ const createOrUpdateAlias = async (instance, inputs, clients) => {
 module.exports = {
   generateId,
   sleep,
+  getAppDirectory,
   getClients,
   packageExpress,
   createOrUpdateFunctionRole,

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const utils = require('../src/utils');
+
+describe('Unit Tests', () => {
+  describe('utils tests', () => {
+    test('inputs config with no dist folder defaults to root directory', () => {
+      const inputs = {
+        src: './',
+      };
+      expect(utils.getAppDirectory(inputs)).toEqual('./');
+    });
+
+    test('inputs config with dist folder uses that as the app directory', () => {
+      const inputs = {
+        src: './',
+        dist: './dist',
+      };
+      expect(utils.getAppDirectory(inputs)).toEqual('./dist');
+    });
+  });
+});


### PR DESCRIPTION
Resolves #60 

I'm still having issues with deploying from a dist folder so I thought I'd give a fix a try. Just looking at the code it seems like this might do it.

I haven't actually got to test this with a real deployment yet. It seems like just using the integration tests is the easiest way to do that. Is there any reason I can't/shouldn't just provide some AWS credentials locally for a personal AWS account and run the integration test to give it a shot? I'm not sure the best way to setup the folder structure specific to this use case but generic to the integration tests, I'm open to opinions/thoughts there.