### PR TITLE
Add dependency build script to typescript webpack template package.json

### DIFF
--- a/templates/express-starter-typescript-webpack/package.json
+++ b/templates/express-starter-typescript-webpack/package.json
@@ -14,7 +14,8 @@
     "webpack-cli": "^3.3.12"
   },
   "scripts": {
-    "build": "webpack && npm i --only=prod --prefix=build/",
+    "build": "webpack && npm run build-dependencies",
+    "build-dependencies": "cp package*.json build/ && npm i --only=prod --prefix=build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
This is required for typescript projects after v2 of this component, but wasn't included in the webpack template. It was on the tsc component already, it just hadn't been copied over here as well.

I did verify the webpack template without this did not work, but with this config it did. This was the root cause of #60. 