### PR TITLE
Retry if rate exceeded

### DIFF
--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,5 +1,5 @@
 name: express
-version: 2.0.4
+version: 2.0.5
 author: eahefnawy
 org: serverlessinc
 description: Deploys a serverless Express.js application onto AWS Lambda and AWS HTTP API.


### PR DESCRIPTION
AWS could throw a "Rate exceeded" at any point when deploying multiple resources, this change makes sure to retry when that happens.