### PR TITLE
fix error "Cannot find module"

### DIFF
--- a/templates/express-starter-typescript-tsc/package-lock.json
+++ b/templates/express-starter-typescript-tsc/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "src",
+  "name": "express-starter-typescript-tsc",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/templates/express-starter-typescript-tsc/package.json
+++ b/templates/express-starter-typescript-tsc/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "private": true,
+  "main": "app.js",
   "dependencies": {
     "express": "^4.17.1"
   },

--- a/templates/express-starter-typescript-tsc/src/app.ts
+++ b/templates/express-starter-typescript-tsc/src/app.ts
@@ -1,4 +1,4 @@
-import * as express from 'express';
+import express from 'express';
 
 const app = express();
 

--- a/templates/express-starter-typescript-tsc/tsconfig.json
+++ b/templates/express-starter-typescript-tsc/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "target": "es5",
     "jsx": "react",
+    "esModuleInterop": true,
     "allowJs": true
   },
   "include": ["./src"]


### PR DESCRIPTION
This was the root cause of [#60](https://github.com/serverless-components/express/issues/60).